### PR TITLE
Display login errors

### DIFF
--- a/Code_site/index.js
+++ b/Code_site/index.js
@@ -630,7 +630,7 @@ app.post('/login', async (req, res) => {
       // If user not found
       if (!user) {
           res.locals.errorMessage = 'User with this email does not exist.';
-          return res.render('pages/login');
+          return res.render('pages/login', { errorMessage: res.locals.errorMessage });
       }
 
       // Check if password matches
@@ -638,7 +638,7 @@ app.post('/login', async (req, res) => {
       if (!match) {
           // Password doesn't match
           res.locals.errorMessage = 'Incorrect password';
-          return res.render('pages/login');
+          return res.render('pages/login', { errorMessage: res.locals.errorMessage });
       }
 
       // If all checks pass, save user details in session and redirect to /discover
@@ -648,7 +648,7 @@ app.post('/login', async (req, res) => {
   } catch (error) {
       // If there's a database or other error
       res.locals.errorMessage = 'An error occurred during login. Please try again later.';
-      res.render('pages/login');
+      res.render('pages/login', { errorMessage: res.locals.errorMessage });
   }
 });
 

--- a/Code_site/views/pages/login.ejs
+++ b/Code_site/views/pages/login.ejs
@@ -233,6 +233,10 @@
 
             <h2 class="welcome" style="margin-top:1rem;">Welcome back!</h2>
 
+            <% if (typeof errorMessage !== 'undefined' && errorMessage) { %>
+                <div class="alert alert-danger" role="alert"><%= errorMessage %></div>
+            <% } %>
+
             <!-- login.ejs -->
 
             <form action="/login" method="POST">


### PR DESCRIPTION
## Summary
- show login errors on the login page
- pass error message context on failed login attempts

## Testing
- `npm test` *(fails: missing script)*
- `npx ejs-lint views/pages/login.ejs`

------
https://chatgpt.com/codex/tasks/task_e_68668294ceb88321826838af59a7c9f1